### PR TITLE
moved cwd setting into config.yaml for more consistant usage

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -10,6 +10,10 @@ defaults:
     - override hydra/job_logging: colorlog
     - override hydra/hydra_logging: colorlog
 
+hydra:
+    run:
+        dir: outputs/${mode_name}/${name}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
 
 save_config: True
 

--- a/configs/mode/development.yaml
+++ b/configs/mode/development.yaml
@@ -2,8 +2,4 @@
 
 development_mode: True
 
-run_root_dir: outputs/development
-
-hydra:
-    run:
-        dir: ${run_root_dir}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+mode_name: development

--- a/configs/mode/experiment.yaml
+++ b/configs/mode/experiment.yaml
@@ -2,11 +2,7 @@
 
 experiment_mode: True
 
-run_root_dir: outputs/experiments
+mode_name: experiments
 
 # name of the experiment
 name: ???
-
-hydra:
-    run:
-        dir: ${run_root_dir}/${name}/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/configs/mode/hip.yaml
+++ b/configs/mode/hip.yaml
@@ -2,11 +2,7 @@
 
 experiment_mode: True
 
-run_root_dir: outputs/hip
+mode_name: hip
 
 # name of the experiment
 name: ???
-
-hydra:
-    run:
-        dir: ${run_root_dir}/${name}/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/configs/mode/hip_networks.yaml
+++ b/configs/mode/hip_networks.yaml
@@ -2,11 +2,7 @@
 
 experiment_mode: True
 
-run_root_dir: outputs/hip_networks
+mode_name: hip_networks
 
 # name of the experiment
 name: ???
-
-hydra:
-    run:
-        dir: ${run_root_dir}/${name}/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/configs/mode/hip_tiles.yaml
+++ b/configs/mode/hip_tiles.yaml
@@ -2,11 +2,7 @@
 
 experiment_mode: True
 
-run_root_dir: outputs/hip_tiles
+mode_name: hip_tiles
 
 # name of the experiment
 name: ???
-
-hydra:
-    run:
-        dir: ${run_root_dir}/${name}/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/configs/mode/ijdar.yaml
+++ b/configs/mode/ijdar.yaml
@@ -2,11 +2,7 @@
 
 experiment_mode: True
 
-run_root_dir: outputs/ijdar
+mode_name: ijdar
 
 # name of the experiment
 name: ???
-
-hydra:
-    run:
-        dir: ${run_root_dir}/${name}/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/configs/mode/tiles_segmentation.yaml
+++ b/configs/mode/tiles_segmentation.yaml
@@ -2,11 +2,7 @@
 
 experiment_mode: True
 
-run_root_dir: outputs/tiles_segmentation
+mode_name: tiles_segmentation
 
 # name of the experiment
 name: ???
-
-hydra:
-    run:
-        dir: ${run_root_dir}/${name}/${now:%Y-%m-%d}/${now:%H-%M-%S}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # --------- pytorch --------- #
 torch==1.12.1
 torchvision==0.13.1
-pytorch-lightning==1.8.3
+pytorch-lightning==1.8.5
 lightning-bolts==0.5.0
 torchmetrics==0.11.0
 

--- a/src/datamodules/utils/single_transforms.py
+++ b/src/datamodules/utils/single_transforms.py
@@ -171,7 +171,7 @@ class MorphoBuilding:
         morpho_filter_1, morpho_filter_2 = self._get_filters(img=img)
         return torch.stack((morpho_filter_1, morpho_filter_2, torch.zeros(morpho_filter_1.shape)), dim=1)[0]
 
-    def _get_filters(self, img: "PIL.Image") -> Tuple[torch.Tensor, torch.Tensor]:
+    def _get_filters(self, img: Image) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Creates the two filter for the read and green channel with the morphological operations.
 

--- a/tests/datamodules/test_base_datamodule.py
+++ b/tests/datamodules/test_base_datamodule.py
@@ -1,4 +1,5 @@
 import pytest
+import re
 from src.datamodules.base_datamodule import AbstractDatamodule
 
 
@@ -20,8 +21,13 @@ def test_check_min_num_samples_no_drop_error(caplog):
     AbstractDatamodule.check_min_num_samples(num_devices=4, batch_size_input=batch_size, num_samples=num_samples,
                                              data_split=data_split,
                                              drop_last=False)
-    assert f'WARNING  src.datamodules.base_datamodule:rank_zero.py:24 ' \
-           f'#samples ({num_samples}) in "{data_split}" smaller than ' \
-           f'#devices (4) times batch size ({batch_size}). ' \
-           f'This works due to drop_last=False, however samples might occur multiple times. ' \
-           f'Check if this behavior is intended!\n' in caplog.text
+    expect_base = fr'WARNING  src\.datamodules\.base_datamodule:rank_zero.py:\d\d '
+    expect_1 = f'#samples ({num_samples}) in "{data_split}" smaller than '
+    expect_2 = f'#devices (4) times batch size ({batch_size}). '
+    expect_3 = f'This works due to drop_last=False, however samples might occur multiple times. '
+    expect_4 = f'Check if this behavior is intended!\n'
+    assert re.search(expect_base, caplog.text)
+    assert expect_1 in caplog.text
+    assert expect_2 in caplog.text
+    assert expect_3 in caplog.text
+    assert expect_4 in caplog.text


### PR DESCRIPTION
### Description
We moved the run dir definition into the general config file to always have the same output folder structure. In the mode files, we define just the mode's name, no longer the whole path.

### How to Test/Run?
`pytest`

